### PR TITLE
a fix a hg.py backend issue involving any revision 0 file

### DIFF
--- a/pyvcs/backends/hg.py
+++ b/pyvcs/backends/hg.py
@@ -69,7 +69,10 @@ class Repository(BaseRepository):
         Returns a list of files in a directory (list of strings) at a given
         revision, or HEAD if revision is None.
         """
-        chgctx = self.repo.changectx(revision or 'tip')
+        if revision is None:
+            chgctx = self.repo.changectx('tip')
+        else:
+            chgctx = self.repo.changectx(revision)
         file_list = []
         folder_list = set()
         found_path = False
@@ -92,7 +95,10 @@ class Repository(BaseRepository):
         Returns the contents of a file as a string at a given revision, or
         HEAD if revision is None.
         """
-        chgctx = self.repo.changectx(revision or 'tip')
+        if revision is None:
+            chgctx = self.repo.changectx('tip')
+        else:
+            chgctx = self.repo.changectx(revision)
         try:
             return chgctx.filectx(path).data()
         except KeyError:


### PR DESCRIPTION
The issue is that if the revision==0 it gets evaluated to False which is also what None gets evaluated to:

```
def file_contents(self, path, revision=None):
    """
    Returns the contents of a file as a string at a given revision, or
    HEAD if revision is None.
    """
    chgctx = self.repo.changectx(revision or 'tip')
```

In the above example, if revision==0 it's going to pick 'tip' instead which of course wrecks a revision 0 comparison to revision 1 because it'll use the 'tip' instead of revision 0. So my change fixes that. A bit brute force to be explicitly looking for None but it's clear and fixes the issue.

New version:

```
def file_contents(self, path, revision=None):
    """
    Returns the contents of a file as a string at a given revision, or
    HEAD if revision is None.
    """
    if revision is None:
        chgctx = self.repo.changectx('tip')
    else:
        chgctx = self.repo.changectx(revision)
```
